### PR TITLE
Temp settings to improve performance and metrics for API rate limiters

### DIFF
--- a/app/api/server/api.js
+++ b/app/api/server/api.js
@@ -199,6 +199,14 @@ export class APIClass extends Restivus {
 		response.setHeader('X-RateLimit-Reset', new Date().getTime() + attemptResult.timeToReset);
 
 		if (!attemptResult.allowed) {
+			metrics.restApiRateLimitExceeded.inc({
+				user_id: userId,
+				client_address: objectForRateLimitMatch.IPAddr,
+				method: request.method.toLowerCase(),
+				endpoint: request.route,
+				user_agent: request.headers['user-agent'],
+			});
+
 			throw new Meteor.Error('error-too-many-requests', `Error, too many requests. Please slow down. You must wait ${ timeToResetAttempsInSeconds } seconds before trying this endpoint again.`, {
 				timeToReset: attemptResult.timeToReset,
 				seconds: timeToResetAttempsInSeconds,
@@ -299,15 +307,17 @@ export class APIClass extends Restivus {
 				const originalAction = endpoints[method].action;
 				const api = this;
 				endpoints[method].action = function _internalRouteActionHandler() {
+					const requestIp = getRequestIP(this.request);
 					const rocketchatRestApiEnd = metrics.rocketchatRestApi.startTimer({
 						method,
 						version,
 						user_agent: this.request.headers['user-agent'],
 						entrypoint: route,
+						user_id: this.userId,
+						client_address: requestIp,
 					});
 
 					logger.debug(`${ this.request.method.toUpperCase() }: ${ this.request.url }`);
-					const requestIp = getRequestIP(this.request);
 					const objectForRateLimitMatch = {
 						IPAddr: requestIp,
 						route: `${ this.request.route }${ this.request.method.toLowerCase() }`,

--- a/app/api/server/api.js
+++ b/app/api/server/api.js
@@ -313,8 +313,8 @@ export class APIClass extends Restivus {
 						version,
 						user_agent: this.request.headers['user-agent'],
 						entrypoint: route,
-						user_id: this.userId,
-						client_address: requestIp,
+						user_id: settings.get('API_Enable_Rate_Limiter_Track_UserId') ? this.userId : undefined,
+						client_address: settings.get('API_Enable_Rate_Limiter_Track_IP') ? requestIp : undefined,
 					});
 
 					logger.debug(`${ this.request.method.toUpperCase() }: ${ this.request.url }`);

--- a/app/api/server/v1/users.js
+++ b/app/api/server/v1/users.js
@@ -679,6 +679,12 @@ API.v1.addRoute('users.removePersonalAccessToken', { authRequired: true }, {
 
 API.v1.addRoute('users.presence', { authRequired: true }, {
 	get() {
+		if (settings.get('Temp_Disable_presence')) {
+			return {
+				users: [],
+				full: false,
+			};
+		}
 		const { from } = this.queryParams;
 
 		const options = {

--- a/app/lib/server/startup/settings.js
+++ b/app/lib/server/startup/settings.js
@@ -2818,6 +2818,8 @@ settings.addGroup('Rate Limiter', function() {
 	this.section('API Rate Limiter', function() {
 		this.add('API_Enable_Rate_Limiter', true, { type: 'boolean' });
 		this.add('API_Enable_Rate_Limiter_Dev', true, { type: 'boolean', enableQuery: { _id: 'API_Enable_Rate_Limiter', value: true } });
+		this.add('API_Enable_Rate_Limiter_Track_UserId', false, { type: 'boolean', enableQuery: { _id: 'API_Enable_Rate_Limiter', value: true } });
+		this.add('API_Enable_Rate_Limiter_Track_IP', false, { type: 'boolean', enableQuery: { _id: 'API_Enable_Rate_Limiter', value: true } });
 		this.add('API_Enable_Rate_Limiter_Limit_Calls_Default', 10, { type: 'int', enableQuery: { _id: 'API_Enable_Rate_Limiter', value: true } });
 		this.add('API_Enable_Rate_Limiter_Limit_Time_Default', 60000, { type: 'int', enableQuery: { _id: 'API_Enable_Rate_Limiter', value: true } });
 	});

--- a/app/lib/server/startup/settings.js
+++ b/app/lib/server/startup/settings.js
@@ -751,6 +751,12 @@ settings.addGroup('General', function() {
 			},
 		],
 	});
+	this.add('Temp_Disable_presence', false, {
+		type: 'boolean',
+	});
+	this.add('Temp_Disable_session', false, {
+		type: 'boolean',
+	});
 	this.add('Site_Url', typeof __meteor_runtime_config__ !== 'undefined' && __meteor_runtime_config__ !== null ? __meteor_runtime_config__.ROOT_URL : null, {
 		type: 'string',
 		i18nDescription: 'Site_Url_Description',

--- a/app/metrics/server/lib/metrics.js
+++ b/app/metrics/server/lib/metrics.js
@@ -36,7 +36,13 @@ metrics.rocketchatHooks = new client.Summary({
 metrics.rocketchatRestApi = new client.Summary({
 	name: 'rocketchat_rest_api',
 	help: 'summary of rocketchat rest api count and time',
-	labelNames: ['method', 'entrypoint', 'user_agent', 'status', 'version'],
+	labelNames: ['method', 'entrypoint', 'user_agent', 'status', 'version', 'user_id', 'client_address'],
+});
+
+metrics.restApiRateLimitExceeded = new client.Counter({
+	name: 'rocketchat_rest_api_rate_limit_exceeded',
+	labelNames: ['user_id', 'client_address', 'method', 'endpoint', 'user_agent'],
+	help: 'number of times a rest api rate limiter was exceeded',
 });
 
 metrics.meteorSubscriptions = new client.Summary({

--- a/app/statistics/server/functions/get.js
+++ b/app/statistics/server/functions/get.js
@@ -136,12 +136,14 @@ statistics.get = function _getStatistics() {
 	statistics.mongoVersion = mongoVersion;
 	statistics.mongoStorageEngine = mongoStorageEngine;
 
-	statistics.uniqueUsersOfYesterday = Sessions.getUniqueUsersOfYesterday();
-	statistics.uniqueUsersOfLastMonth = Sessions.getUniqueUsersOfLastMonth();
-	statistics.uniqueDevicesOfYesterday = Sessions.getUniqueDevicesOfYesterday();
-	statistics.uniqueDevicesOfLastMonth = Sessions.getUniqueDevicesOfLastMonth();
-	statistics.uniqueOSOfYesterday = Sessions.getUniqueOSOfYesterday();
-	statistics.uniqueOSOfLastMonth = Sessions.getUniqueOSOfLastMonth();
+	if (!settings.get('Temp_Disable_session')) {
+		statistics.uniqueUsersOfYesterday = Sessions.getUniqueUsersOfYesterday();
+		statistics.uniqueUsersOfLastMonth = Sessions.getUniqueUsersOfLastMonth();
+		statistics.uniqueDevicesOfYesterday = Sessions.getUniqueDevicesOfYesterday();
+		statistics.uniqueDevicesOfLastMonth = Sessions.getUniqueDevicesOfLastMonth();
+		statistics.uniqueOSOfYesterday = Sessions.getUniqueOSOfYesterday();
+		statistics.uniqueOSOfLastMonth = Sessions.getUniqueOSOfLastMonth();
+	}
 
 	statistics.apps = {
 		engineVersion: Info.marketplaceApiVersion,

--- a/app/statistics/server/startup/monitor.js
+++ b/app/statistics/server/startup/monitor.js
@@ -2,9 +2,13 @@ import { Meteor } from 'meteor/meteor';
 import { InstanceStatus } from 'meteor/konecty:multiple-instances-status';
 
 import { SAUMonitorClass } from '../lib/SAUMonitor';
+import { settings } from '../../../settings/server';
 
 const SAUMonitor = new SAUMonitorClass();
 
 Meteor.startup(() => {
+	if (settings.get('Temp_Disable_session')) {
+		return SAUMonitor.stop();
+	}
 	SAUMonitor.start(InstanceStatus.id());
 });

--- a/imports/users-presence/server/activeUsers.js
+++ b/imports/users-presence/server/activeUsers.js
@@ -1,6 +1,7 @@
 import { UserPresenceEvents } from 'meteor/konecty:user-presence';
 
 import { Notifications } from '../../../app/notifications/server';
+import { settings } from '../../../app/settings/server';
 
 // mirror of object in /imports/startup/client/listenActiveUsers.js - keep updated
 const STATUS_MAP = {
@@ -10,7 +11,7 @@ const STATUS_MAP = {
 	busy: 3,
 };
 
-UserPresenceEvents.on('setUserStatus', (user, status/* , statusConnection*/) => {
+const notifyStatus = (user, status/* , statusConnection*/) => {
 	const {
 		_id,
 		username,
@@ -25,4 +26,11 @@ UserPresenceEvents.on('setUserStatus', (user, status/* , statusConnection*/) => 
 		STATUS_MAP[status],
 		statusText,
 	]);
+};
+
+settings.get('Temp_Disable_presence', (key, value) => {
+	if (value) {
+		return UserPresenceEvents.removeListener('setUserStatus', notifyStatus);
+	}
+	UserPresenceEvents.on('setUserStatus', notifyStatus);
 });


### PR DESCRIPTION
This PR adds the following functionalities:

- Add a new metric to show API rate limiter exceeds
- A new setting to disable user presence reporting to clients
- A new setting to disable rocket.chat usage session aggregates

Both settings can be found under Admin > General section.