### PR TITLE
[AR-2515] Change searching username/email from case-insensitive regex to collation

### DIFF
--- a/app/lib/server/functions/checkEmailAvailability.js
+++ b/app/lib/server/functions/checkEmailAvailability.js
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import s from 'underscore.string';
-import { escapeRegExp } from '@rocket.chat/string-helpers';
 
 export const checkEmailAvailability = function(email) {
-	return !Meteor.users.findOne({ 'emails.address': { $regex: new RegExp(`^${ s.trim(escapeRegExp(email)) }$`, 'i') } });
+	return !Meteor.users.find({ 'emails.address': s.trim(email) }).collation({ locale: 'en', strength: 2 }).fetch()[0];
 };

--- a/app/lib/server/functions/checkUsernameAvailability.js
+++ b/app/lib/server/functions/checkUsernameAvailability.js
@@ -24,9 +24,9 @@ export const checkUsernameAvailability = function(username) {
 	}
 
 	// Make sure no users are using this username
-	const existingUser = Meteor.users.findOne({
-		username: toRegExp(username),
-	}, { fields: { _id: 1 } });
+	const existingUser = Meteor.users.find({
+		username: username,
+	}, { fields: { _id: 1 } }).collation({ locale: 'en', strength: 2 }).fetch()[0];
 	if (existingUser) {
 		return false;
 	}

--- a/app/lib/server/functions/getUsernameSuggestion.js
+++ b/app/lib/server/functions/getUsernameSuggestion.js
@@ -66,9 +66,8 @@ export function generateUsernameSuggestion(user) {
 
 	usernames.push(settings.get('Accounts_DefaultUsernamePrefixSuggestion'));
 
-	let index = Users.find({ username: new RegExp(`^${ usernames[0] }-[0-9]+`) }).count();
-	const username = '';
-	while (!username) {
+	let index = 1;
+	while (true) {
 		if (usernameIsAvaliable(`${ usernames[0] }-${ index }`)) {
 			return `${ usernames[0] }-${ index }`;
 		}


### PR DESCRIPTION
Case insensitive regex cannot leverage index, collation search, however can leverage respective collation index and so instead of fullscan this query will find the user immediately
generateUsernameSuggestion: previously it tried to reduce number of iterations by checking how many nicks were already created like this. However, this search has to do fulltable scan, while a single username search is efficient, so better to always iterate from 1. Thought for the future, maybe it's better to just do random of 1000 instead of consecutive number.