### PR TITLE
Check status and pass headers when proxy-streaming from file-store

### DIFF
--- a/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
+++ b/apps/meteor/packages/rocketchat-i18n/i18n/en.i18n.json
@@ -5741,7 +5741,7 @@
   "registration.component.login.incorrectPassword": "Incorrect password",
   "registration.component.switchLanguage": "Switch to <1>en</1>",
   "registration.component.resetPassword": "Reset password",
-  "registration.component.form.emailOrUsername": "Email or username",
+  "registration.component.form.emailOrUsername": "Email address",
   "registration.component.form.username": "Username",
   "registration.component.form.name": "Name",
   "registration.component.form.nameOptional": "Name optional",

--- a/packages/web-ui-registration/src/components/RegisterTitle.tsx
+++ b/packages/web-ui-registration/src/components/RegisterTitle.tsx
@@ -1,13 +1,18 @@
 import { useSetting } from '@rocket.chat/ui-contexts';
 import type { ReactElement } from 'react';
-import { Trans } from 'react-i18next';
 
 export const RegisterTitle = (): ReactElement | null => {
-	const siteName = useSetting<string>('Site_Name');
 	const hideTitle = useSetting<boolean>('Layout_Login_Hide_Title');
 
 	if (hideTitle) {
 		return null;
 	}
-	return <Trans i18nKey='registration.component.welcome'>Welcome to {siteName} workspace</Trans>;
+
+	return (
+		<>
+			Seeking Alpha
+			<br />
+			Investing Groups
+		</>
+	);
 };

--- a/packages/web-ui-registration/src/components/RegisterTitle.tsx
+++ b/packages/web-ui-registration/src/components/RegisterTitle.tsx
@@ -8,7 +8,7 @@ export const RegisterTitle = (): ReactElement | null => {
 		return null;
 	}
 
-	return (
+	return(
 		<>
 			Seeking Alpha
 			<br />


### PR DESCRIPTION
Before this change, when there was any issue during proxy, `fileRes.pipe` might have proxied 0 bytes, or proxy error body from store with status 200.

Such issues might be temporary, for example due to eventual consistency on S3 upload, but because  the response status is 200 and caching headers are set for a year, this can cause invalid response to be cached forever when using cdn-cache.